### PR TITLE
feat: 持久化 userInfo, middleware 處理導向

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
     "framer-motion": "^10.12.4",
+    "js-cookie": "^3.0.5",
     "next": "13.3.0",
     "postcss": "8.4.21",
     "react": "18.2.0",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.5.1",
     "@commitlint/config-conventional": "^17.4.4",
+    "@types/js-cookie": "^3.0.3",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-tailwindcss": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "next lint",
     "lint:lint-staged": "lint-staged",
     "format": "prettier --write \"./**/*.{html,tsx,jsx,ts,js,json,md}\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ dependencies:
   framer-motion:
     specifier: ^10.12.4
     version: 10.12.4(react-dom@18.2.0)(react@18.2.0)
+  js-cookie:
+    specifier: ^3.0.5
+    version: 3.0.5
   next:
     specifier: 13.3.0
     version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
@@ -72,6 +75,9 @@ devDependencies:
   '@commitlint/config-conventional':
     specifier: ^17.4.4
     version: 17.4.4
+  '@types/js-cookie':
+    specifier: ^3.0.3
+    version: 3.0.3
   eslint-config-prettier:
     specifier: ^8.8.0
     version: 8.8.0(eslint@8.38.0)
@@ -1736,6 +1742,10 @@ packages:
 
   /@tsconfig/node16@1.0.3:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+
+  /@types/js-cookie@3.0.3:
+    resolution: {integrity: sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww==}
+    dev: true
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -3635,6 +3645,11 @@ packages:
   /jiti@1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
+
+  /js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+    dev: false
 
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}

--- a/src/components/Layout/header.tsx
+++ b/src/components/Layout/header.tsx
@@ -105,7 +105,7 @@ const Header = () => {
 
           <Box alignItems="center" className="hidden md:flex">
             <Center className="mr-8 cursor-pointer">
-              <Icon as={AiOutlineSearch} mr={1} className=" text-xl" />
+              <Icon as={AiOutlineSearch} mr={1} className="text-xl" />
               搜尋
             </Center>
             <Button colorScheme="primary" width={81} onClick={logout}>

--- a/src/components/Layout/header.tsx
+++ b/src/components/Layout/header.tsx
@@ -23,14 +23,23 @@ import {
 import { AiOutlineSearch } from 'react-icons/ai';
 import { FaBars } from 'react-icons/fa';
 import { GrClose } from 'react-icons/gr';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { localStg } from '@/utils';
 import { useRouter } from 'next/router';
 import { useAuthStore } from '@/store';
 
 const Header = () => {
   const router = useRouter();
-  const { isLogin, setIsLogin } = useAuthStore();
+  // const { isLogin, setIsLogin } = useAuthStore();
+  const hasHydrated = useAuthStore((state) => state._hasHydrated);
+  const loginStatus = useAuthStore((state) => state.getters.isLogin);
+  const [isLogin, setIsLogin] = useState(false);
+
+  useEffect(() => {
+    if (hasHydrated) {
+      setIsLogin(loginStatus);
+    }
+  }, [hasHydrated]);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -43,8 +52,9 @@ const Header = () => {
       router.push('/login');
       return;
     }
-    setIsLogin(false);
-    localStg.remove('userInfo');
+    // setIsLogin(false);
+    // localStg.remove('userInfo');
+    useAuthStore.persist.clearStorage();
     router.push('/');
   };
 
@@ -100,7 +110,7 @@ const Header = () => {
               搜尋
             </Center>
             <Button colorScheme="primary" width={81} onClick={logout}>
-              {isLogin ? '登出' : '登入'}
+              {hasHydrated && isLogin ? '登出' : '登入'}
             </Button>
           </Box>
 
@@ -154,7 +164,7 @@ const Header = () => {
 
           <DrawerFooter pt={0}>
             <Button colorScheme="primary" width={'100%'}>
-              {isLogin ? '登出' : '登入'}
+              {hasHydrated && isLogin ? '登出' : '登入'}
             </Button>
           </DrawerFooter>
         </DrawerContent>

--- a/src/components/Layout/header.tsx
+++ b/src/components/Layout/header.tsx
@@ -24,13 +24,13 @@ import { AiOutlineSearch } from 'react-icons/ai';
 import { FaBars } from 'react-icons/fa';
 import { GrClose } from 'react-icons/gr';
 import { useState, useEffect } from 'react';
-import { localStg } from '@/utils';
 import { useRouter } from 'next/router';
 import { useAuthStore } from '@/store';
+import { useCookie } from '@/hooks';
 
 const Header = () => {
   const router = useRouter();
-  // const { isLogin, setIsLogin } = useAuthStore();
+  const [value, updateCookie, deleteCookie] = useCookie('token');
   const hasHydrated = useAuthStore((state) => state._hasHydrated);
   const loginStatus = useAuthStore((state) => state.getters.isLogin);
   const [isLogin, setIsLogin] = useState(false);
@@ -39,7 +39,7 @@ const Header = () => {
     if (hasHydrated) {
       setIsLogin(loginStatus);
     }
-  }, [hasHydrated]);
+  }, [hasHydrated, loginStatus]);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -52,9 +52,8 @@ const Header = () => {
       router.push('/login');
       return;
     }
-    // setIsLogin(false);
-    // localStg.remove('userInfo');
     useAuthStore.persist.clearStorage();
+    deleteCookie();
     router.push('/');
   };
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,20 +1,18 @@
 import { FC, ReactNode } from 'react';
 import Header from './header';
 import Footer from './footer';
-import { useEffect } from 'react';
-import { useAuthStore } from '@/store';
-import { getToken } from '@/service/request/helpers';
 
 interface LayoutProps {
   children: ReactNode;
 }
 
 const Layout: FC<LayoutProps> = ({ children }) => {
-  const { isLogin, setIsLogin } = useAuthStore();
-  useEffect(() => {
-    const token = getToken();
-    if (token) setIsLogin(true);
-  }, [isLogin, setIsLogin]);
+  // const { isLogin, setIsLogin } = useAuthStore();
+
+  // useEffect(() => {
+  //   const token = getToken();
+  //   if (token) setIsLogin(true);
+  // }, [isLogin, setIsLogin]);
 
   return (
     <>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -7,13 +7,6 @@ interface LayoutProps {
 }
 
 const Layout: FC<LayoutProps> = ({ children }) => {
-  // const { isLogin, setIsLogin } = useAuthStore();
-
-  // useEffect(() => {
-  //   const token = getToken();
-  //   if (token) setIsLogin(true);
-  // }, [isLogin, setIsLogin]);
-
   return (
     <>
       <Header />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useTimeoutFn } from './useTimeoutFn';
+export * from './useCookie';

--- a/src/hooks/useCookie.ts
+++ b/src/hooks/useCookie.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from 'react';
+import Cookies from 'js-cookie';
+
+export const useCookie = (
+  cookieName: string
+): [
+  string | null,
+  (newValue: string, options?: Cookies.CookieAttributes) => void,
+  () => void
+] => {
+  const [value, setValue] = useState<string | null>(
+    () => Cookies.get(cookieName) || null
+  );
+
+  const updateCookie = useCallback(
+    (newValue: string, options?: Cookies.CookieAttributes) => {
+      Cookies.set(cookieName, newValue, options);
+      setValue(newValue);
+    },
+    [cookieName]
+  );
+
+  const deleteCookie = useCallback(() => {
+    Cookies.remove(cookieName);
+    setValue(null);
+  }, [cookieName]);
+
+  return [value, updateCookie, deleteCookie];
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import Cookies from 'js-cookie';
+
+// This function can be marked `async` if using `await` inside
+export function middleware(request: NextRequest) {
+  const paths = ['/login', '/signup'];
+  const userToken = request.cookies.get('token')?.value;
+  if (!!userToken && paths.includes(request.nextUrl.pathname)) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: ['/login', '/signup']
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-import Cookies from 'js-cookie';
+import type { NextFetchEvent, NextRequest } from 'next/server';
 
-// This function can be marked `async` if using `await` inside
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
   const paths = ['/login', '/signup'];
   const userToken = request.cookies.get('token')?.value;
   if (!!userToken && paths.includes(request.nextUrl.pathname)) {
     return NextResponse.redirect(new URL('/', request.url));
   }
+  return NextResponse.next();
 }
 
 // See "Matching Paths" below to learn more

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -26,12 +26,10 @@ import {
 } from '@chakra-ui/react';
 import { FcGoogle } from 'react-icons/fc';
 import { useAuthStore } from '@/store';
-import { useCookie } from '@/hooks';
 
 const Login: App.NextPageWithLayout = () => {
   const router = useRouter();
   const setUserInfo = useAuthStore((state) => state.setUserInfo);
-  const [value, updateCookie, deleteCookie] = useCookie('token');
 
   const [modal, setModal] = useState<ModalState>({
     isOpen: false,
@@ -69,7 +67,6 @@ const Login: App.NextPageWithLayout = () => {
     if (res) {
       if (res.status !== 'Success') return;
       setUserInfo(res.data);
-      updateCookie(res.data.token);
       router.push('/');
     }
   };

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -8,8 +8,7 @@ import ModalBox, { type ModalState } from '@/components/Modal';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
-import { safeAwait, localStg } from '@/utils';
-import { getToken } from '@/service/request/helpers';
+import { safeAwait } from '@/utils';
 import {
   Box,
   Container,
@@ -30,7 +29,9 @@ import { useAuthStore } from '@/store';
 
 const Login: App.NextPageWithLayout = () => {
   const router = useRouter();
-  const { setIsLogin } = useAuthStore();
+  // const { setIsLogin } = useAuthStore();
+  const setUserInfo = useAuthStore((state) => state.setUserInfo);
+  const isLogin = useAuthStore((state) => state.getters.isLogin);
 
   const [modal, setModal] = useState<ModalState>({
     isOpen: false,
@@ -67,16 +68,17 @@ const Login: App.NextPageWithLayout = () => {
 
     if (res) {
       if (res.status !== 'Success') return;
-      localStg.set('userInfo', res.data);
-      setIsLogin(true);
+      // localStg.set('userInfo', res.data);
+      setUserInfo(res.data);
+      // setIsLogin(true);
       router.push('/');
     }
   };
 
   useEffect(() => {
-    const token = getToken();
-    if (token) router.push('/');
-  }, [router]);
+    // const token = getToken();
+    if (isLogin) router.push('/');
+  }, [router, isLogin]);
 
   return (
     <>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import type { ReactElement } from 'react';
 import { apiPostLogin } from '@/service/api/index';
 import ModalBox, { type ModalState } from '@/components/Modal';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import { safeAwait } from '@/utils';
@@ -26,12 +26,12 @@ import {
 } from '@chakra-ui/react';
 import { FcGoogle } from 'react-icons/fc';
 import { useAuthStore } from '@/store';
+import { useCookie } from '@/hooks';
 
 const Login: App.NextPageWithLayout = () => {
   const router = useRouter();
-  // const { setIsLogin } = useAuthStore();
   const setUserInfo = useAuthStore((state) => state.setUserInfo);
-  const isLogin = useAuthStore((state) => state.getters.isLogin);
+  const [value, updateCookie, deleteCookie] = useCookie('token');
 
   const [modal, setModal] = useState<ModalState>({
     isOpen: false,
@@ -68,17 +68,11 @@ const Login: App.NextPageWithLayout = () => {
 
     if (res) {
       if (res.status !== 'Success') return;
-      // localStg.set('userInfo', res.data);
       setUserInfo(res.data);
-      // setIsLogin(true);
+      updateCookie(res.data.token);
       router.push('/');
     }
   };
-
-  useEffect(() => {
-    // const token = getToken();
-    if (isLogin) router.push('/');
-  }, [router, isLogin]);
 
   return (
     <>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -84,11 +84,6 @@ const Signup: App.NextPageWithLayout = () => {
     clear();
   }, [clear]);
 
-  useEffect(() => {
-    // const token = getToken();
-    if (isLogin) router.push('/');
-  }, [router, isLogin]);
-
   return (
     <>
       <Head>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -5,7 +5,6 @@ import Head from 'next/head';
 import type { ReactElement } from 'react';
 import { useRef } from 'react';
 import { useForm } from 'react-hook-form';
-import { getToken } from '@/service/request/helpers';
 import {
   Box,
   Container,
@@ -30,7 +29,6 @@ import { useAuthStore } from '@/store';
 
 const Signup: App.NextPageWithLayout = () => {
   const router = useRouter();
-  const isLogin = useAuthStore((state) => state.getters.isLogin);
 
   const [modal, setModal] = useState<ModalState>({
     isOpen: false,

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -30,6 +30,7 @@ import { useAuthStore } from '@/store';
 
 const Signup: App.NextPageWithLayout = () => {
   const router = useRouter();
+  const isLogin = useAuthStore((state) => state.getters.isLogin);
 
   const [modal, setModal] = useState<ModalState>({
     isOpen: false,
@@ -84,9 +85,9 @@ const Signup: App.NextPageWithLayout = () => {
   }, [clear]);
 
   useEffect(() => {
-    const token = getToken();
-    if (token) router.push('/');
-  }, [router]);
+    // const token = getToken();
+    if (isLogin) router.push('/');
+  }, [router, isLogin]);
 
   return (
     <>

--- a/src/service/request/helpers.ts
+++ b/src/service/request/helpers.ts
@@ -1,5 +1,6 @@
-import { localStg } from '@/utils';
+// import { localStg } from '@/utils';
+import { useAuthStore } from '@/store';
 
 export function getToken() {
-  return localStg.get('userInfo')?.token || '';
+  return useAuthStore.getState().userInfo?.token || '';
 }

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,11 +1,60 @@
 import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
 
-type AuthState = {
-  isLogin: boolean;
-  setIsLogin: (isLogin: boolean) => void;
+// type AuthState = {
+//   isLogin: boolean;
+//   setIsLogin: (isLogin: boolean) => void;
+// };
+
+// export const useAuthStore = create<AuthState>((set) => ({
+//   isLogin: false,
+//   setIsLogin: (isLogin) => set({ isLogin })
+// }));
+
+type State = {
+  userInfo: ApiAuth.UserInfo | null;
+  _hasHydrated: boolean;
+  getters: {
+    isLogin: boolean;
+  };
 };
 
-export const useAuthStore = create<AuthState>((set) => ({
-  isLogin: false,
-  setIsLogin: (isLogin) => set({ isLogin })
-}));
+type Actions = {
+  setUserInfo: (arg: ApiAuth.UserInfo) => void;
+  setHasHydrated: (state: boolean) => void;
+};
+
+export const useAuthStore = create<State & Actions>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        userInfo: null,
+        _hasHydrated: false,
+        setUserInfo: (params) => {
+          set((state) => ({ ...state, userInfo: params }));
+        },
+        setHasHydrated: (state) => {
+          set({
+            _hasHydrated: state
+          });
+        },
+        getters: {
+          get isLogin() {
+            return !!get().userInfo;
+          }
+        }
+      }),
+      {
+        name: 'userInfo',
+        partialize: (state) =>
+          Object.fromEntries(
+            Object.entries(state).filter(([key]) => ['userInfo'].includes(key))
+          ),
+        onRehydrateStorage: () => (state) => {
+          state && state.setHasHydrated(true);
+        }
+      }
+    ),
+    { name: 'authStore' }
+  )
+);

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,16 +1,6 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
-// type AuthState = {
-//   isLogin: boolean;
-//   setIsLogin: (isLogin: boolean) => void;
-// };
-
-// export const useAuthStore = create<AuthState>((set) => ({
-//   isLogin: false,
-//   setIsLogin: (isLogin) => set({ isLogin })
-// }));
-
 type State = {
   userInfo: ApiAuth.UserInfo | null;
   _hasHydrated: boolean;

--- a/src/utils/service/error.ts
+++ b/src/utils/service/error.ts
@@ -5,7 +5,10 @@ export function handleAxiosError(axiosError: AxiosError<Service.FailedResult>) {
     status: 'Error',
     message: ''
   };
-  if (axiosError.response) {
+  if (!window.navigator.onLine || axiosError.message === 'Network Error') {
+    Object.assign(error, { message: '網路不可用' });
+  }
+  if (!!axiosError.response) {
     Object.assign(error, { message: axiosError.response.data.message });
   }
 


### PR DESCRIPTION
1. 登入後取得的 userInfo 使用 zustand 的持久化方式處理(useAuthStore 全部改寫)
2. 使用 middleware 處理以登入狀態的導向 (/login, /signup)
3. 新增 typecheck 指令於 pre-push 執行，判斷 type 有無錯誤